### PR TITLE
No-line-hard-limit Proposal

### DIFF
--- a/eclipseSettings/leafnode-google-formatting.xml
+++ b/eclipseSettings/leafnode-google-formatting.xml
@@ -74,7 +74,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="140"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="999"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
@@ -205,7 +205,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="140"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="999"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>

--- a/eclipseSettings/leafnode-javascript-formatting.xml
+++ b/eclipseSettings/leafnode-javascript-formatting.xml
@@ -183,7 +183,7 @@
 <setting id="org.eclipse.wst.jsdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
-<setting id="org.eclipse.wst.jsdt.core.formatter.lineSplit" value="140"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.lineSplit" value="999"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.comment.format_html" value="true"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
@@ -229,7 +229,7 @@
 <setting id="org.eclipse.wst.jsdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_before_colon_in_object_initializer" value="do not insert"/>
-<setting id="org.eclipse.wst.jsdt.core.formatter.comment.line_length" value="140"/>
+<setting id="org.eclipse.wst.jsdt.core.formatter.comment.line_length" value="999"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
 <setting id="org.eclipse.wst.jsdt.core.formatter.brace_position_for_block" value="end_of_line"/>

--- a/intellijSettings/bms-xml-no-keep-whitespaces.xml
+++ b/intellijSettings/bms-xml-no-keep-whitespaces.xml
@@ -1,5 +1,5 @@
 <code_scheme name="bms-xml-no-keep-whitespaces" version="173">
-  <option name="RIGHT_MARGIN" value="9999" />
+  <option name="RIGHT_MARGIN" value="999" />
   <CssCodeStyleSettings>
     <option name="KEEP_SINGLE_LINE_BLOCKS" value="true" />
   </CssCodeStyleSettings>
@@ -66,7 +66,7 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="140" />
+    <option name="RIGHT_MARGIN" value="999" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
@@ -104,7 +104,7 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JavaScript">
-    <option name="RIGHT_MARGIN" value="140" />
+    <option name="RIGHT_MARGIN" value="999" />
     <indentOptions>
       <option name="USE_TAB_CHARACTER" value="true" />
     </indentOptions>

--- a/intellijSettings/bms.xml
+++ b/intellijSettings/bms.xml
@@ -1,5 +1,5 @@
 <code_scheme name="bms" version="173">
-  <option name="RIGHT_MARGIN" value="9999" />
+  <option name="RIGHT_MARGIN" value="999" />
   <CssCodeStyleSettings>
     <option name="KEEP_SINGLE_LINE_BLOCKS" value="true" />
   </CssCodeStyleSettings>
@@ -66,7 +66,7 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="140" />
+    <option name="RIGHT_MARGIN" value="999" />
     <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
@@ -108,7 +108,7 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JavaScript">
-    <option name="RIGHT_MARGIN" value="140" />
+    <option name="RIGHT_MARGIN" value="999" />
     <indentOptions>
       <option name="USE_TAB_CHARACTER" value="true" />
     </indentOptions>


### PR DESCRIPTION
This proposal is to extend the hard limit that we have in our code formatting options.
Right now is `140`, but some times this can be a limitation, or can render less readable code than if it were manually split by the developer according to his/her own criteria.

This is specially useful for sql strings:
```java
sql.append(" and nde.nd_experiment_id in (select ph2.nd_experiment_id " //
	+ "      from cvterm_relationship cvtrscale " //
	+ "           inner join cvterm scale on cvtrscale.object_id = scale.cvterm_id " //
	+ "           inner join cvterm_relationship cvtrdataType on scale.cvterm_id = cvtrdataType.subject_id and cvtrdataType.type_id = " + TermId.HAS_TYPE.getId()
	+ "           inner join cvterm dataType on cvtrdataType.object_id = dataType.cvterm_id " //
	+ "           left join cvtermprop scaleMaxRange on scale.cvterm_id = scaleMaxRange.cvterm_id and scaleMaxRange.type_id = " + TermId.MAX_VALUE.getId()
	+ "           left join cvtermprop scaleMinRange on scale.cvterm_id = scaleMinRange.cvterm_id and scaleMinRange.type_id = " + TermId.MIN_VALUE.getId()
	+ " inner join phenotype ph2 on cvtrscale.subject_id = ph2.observable_id " //
	+ "    inner join nd_experiment nde2 on ph2.nd_experiment_id = nde2.nd_experiment_id " //
	+ "           inner join project p2 on nde2.project_id = p2.project_id " //
	+ "           left join variable_overrides vo on vo.cvterm_id = ph2.observable_id and p2.program_uuid = vo.program_uuid " //
			+ "      where ph2." + filterByDraftOrValue + " is not null  and ph2." + filterByDraftOrValue + "!= 'missing'" //
```
Compared to 
```java
sql.append(" and nde.nd_experiment_id in (select ph2.nd_experiment_id " //
	+ "      from cvterm_relationship cvtrscale " //
	+ "           inner join cvterm scale on cvtrscale.object_id = scale.cvterm_id " //
	+ "           inner join cvterm_relationship cvtrdataType on scale.cvterm_id = cvtrdataType.subject_id and cvtrdataType.type_id = "
	+ TermId.HAS_TYPE.getId()
	+ "           inner join cvterm dataType on cvtrdataType.object_id = dataType.cvterm_id " //
	+ "           left join cvtermprop scaleMaxRange on scale.cvterm_id = scaleMaxRange.cvterm_id and scaleMaxRange.type_id = "
	+ TermId.MAX_VALUE.getId()
	+ "           left join cvtermprop scaleMinRange on scale.cvterm_id = scaleMinRange.cvterm_id and scaleMinRange.type_id = "
	+ TermId.MIN_VALUE.getId()
	+ " inner join phenotype ph2 on cvtrscale.subject_id = ph2.observable_id " //
	+ "    inner join nd_experiment nde2 on ph2.nd_experiment_id = nde2.nd_experiment_id " //
	+ "           inner join project p2 on nde2.project_id = p2.project_id " //
	+ "           left join variable_overrides vo on vo.cvterm_id = ph2.observable_id and p2.program_uuid = vo.program_uuid " //
```

This is an example of the typescript codebase, which doesn't seem to have a hard limit on the line length:
https://github.com/microsoft/TypeScript/blob/fd0ad2985b6d88e190dc757abac5a37ba102abb9/src/compiler/commandLineParser.ts#L2053

This proposal is not in favor of long lines, but to avoid automatic splitting.

cc @IntegratedBreedingPlatform/developers 